### PR TITLE
Use env vars for configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DJANGO_SECRET_KEY=
+DB_NAME=carlos-website
+DB_USER=carlos
+DB_PASSWORD=website
+DB_HOST=localhost
+DB_PORT=5432

--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ This repository hosts a Django backend and a React frontend for the website.
    pip install -r backend/requirements.txt
    ```
 
-3. **Configure the database**
+3. **Configure environment variables**
 
-   Update the settings in `backend/core/settings.py` under the `DATABASES` section
-   to match your PostgreSQL credentials. The default configuration expects a local
-   PostgreSQL server with the following values:
+   The backend reads configuration from environment variables. You can create a
+   `.env` file (see `.env.example`) or export the variables in your shell:
 
-   - NAME: `carlos-website`
-   - USER: `carlos`
-   - PASSWORD: `website`
-   - HOST: `localhost`
-   - PORT: `5432`
+   - `DJANGO_SECRET_KEY` – secret key used by Django
+   - `DB_NAME` – database name (default: `carlos-website`)
+   - `DB_USER` – database user (default: `carlos`)
+   - `DB_PASSWORD` – database password (default: `website`)
+   - `DB_HOST` – database host (default: `localhost`)
+   - `DB_PORT` – database port (default: `5432`)
 
 4. **Apply migrations**
 

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -20,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-1)8*g0=8#ij@m6oer4bhfo7-j6f5nxcoqzzi_u)54)8d1-f1*1'
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -77,11 +78,11 @@ WSGI_APPLICATION = 'core.wsgi.application'
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
-        "NAME": "carlos-website",
-        "USER": "carlos",
-        "PASSWORD": "website",
-        "HOST": "localhost",
-        "PORT": "5432",
+        "NAME": os.environ.get("DB_NAME", "carlos-website"),
+        "USER": os.environ.get("DB_USER", "carlos"),
+        "PASSWORD": os.environ.get("DB_PASSWORD", "website"),
+        "HOST": os.environ.get("DB_HOST", "localhost"),
+        "PORT": os.environ.get("DB_PORT", "5432"),
     }
 }
 


### PR DESCRIPTION
## Summary
- load `SECRET_KEY` and database settings from environment variables
- document required environment variables in `README`
- provide `.env.example` with default values

## Testing
- `python backend/manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*